### PR TITLE
Configurable wakelock_debug + Fix gcc 5.2 warnings

### DIFF
--- a/arch/arm/include/asm/ftrace.h
+++ b/arch/arm/include/asm/ftrace.h
@@ -32,7 +32,7 @@ extern void ftrace_call_old(void);
 
 #ifndef __ASSEMBLY__
 
-#if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND)
+#if defined(CONFIG_FRAME_POINTER) || defined(CONFIG_ARM_UNWIND)
 /*
  * return_address uses walk_stackframe to do it's work.  If both
  * CONFIG_FRAME_POINTER=y and CONFIG_ARM_UNWIND=y walk_stackframe uses unwind

--- a/arch/arm/kernel/return_address.c
+++ b/arch/arm/kernel/return_address.c
@@ -11,7 +11,7 @@
 #include <linux/export.h>
 #include <linux/ftrace.h>
 
-#if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND)
+#if defined(CONFIG_FRAME_POINTER) || defined(CONFIG_ARM_UNWIND)
 #include <linux/sched.h>
 
 #include <asm/stacktrace.h>
@@ -56,11 +56,7 @@ void *return_address(unsigned int level)
 		return NULL;
 }
 
-#else /* if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND) */
-
-#if defined(CONFIG_ARM_UNWIND)
-#warning "TODO: return_address should use unwind tables"
-#endif
+#else /* if defined(CONFIG_FRAME_POINTER) || defined(CONFIG_ARM_UNWIND) */
 
 void *return_address(unsigned int level)
 {

--- a/arch/arm/mach-msm/include/mach/qdsp6v2/apr.h
+++ b/arch/arm/mach-msm/include/mach/qdsp6v2/apr.h
@@ -151,9 +151,6 @@ int apr_get_svc(const char *svc_name, int dest_id, int *client_id,
 void apr_cb_func(void *buf, int len, void *priv);
 struct apr_svc *apr_register(char *dest, char *svc_name, apr_fn svc_fn,
 					uint32_t src_port, void *priv);
-inline int apr_fill_hdr(void *handle, uint32_t *buf, uint16_t src_port,
-			uint16_t msg_type, uint16_t dest_port,
-			uint32_t token, uint32_t opcode, uint16_t len);
 
 int apr_send_pkt(void *handle, uint32_t *buf);
 int apr_deregister(void *handle);

--- a/drivers/cpufreq/cpufreq_interactive.c
+++ b/drivers/cpufreq/cpufreq_interactive.c
@@ -801,7 +801,8 @@ static ssize_t show_target_loads(
 		ret += sprintf(buf + ret, "%u%s", target_loads[i],
 			       i & 0x1 ? ":" : " ");
 
-	ret += sprintf(buf + --ret, "\n");
+	ret--;
+	ret += sprintf(buf + ret, "\n");
 	spin_unlock_irqrestore(&target_loads_lock, flags);
 	return ret;
 }
@@ -844,7 +845,8 @@ static ssize_t show_above_hispeed_delay(
 		ret += sprintf(buf + ret, "%u%s", above_hispeed_delay[i],
 			       i & 0x1 ? ":" : " ");
 
-	ret += sprintf(buf + --ret, "\n");
+	ret--;
+	ret += sprintf(buf + ret, "\n");
 	spin_unlock_irqrestore(&above_hispeed_delay_lock, flags);
 	return ret;
 }

--- a/drivers/gpu/msm2/adreno_ringbuffer.c
+++ b/drivers/gpu/msm2/adreno_ringbuffer.c
@@ -213,7 +213,7 @@ err:
  *
  * Load the pm4 ucode from @start at @addr.
  */
-inline int adreno_ringbuffer_load_pm4_ucode(struct kgsl_device *device,
+static inline int adreno_ringbuffer_load_pm4_ucode(struct kgsl_device *device,
 			unsigned int start, unsigned int end, unsigned int addr)
 {
 	struct adreno_device *adreno_dev = ADRENO_DEVICE(device);
@@ -267,7 +267,7 @@ err:
  *
  * Load the pfp ucode from @start at @addr.
  */
-inline int adreno_ringbuffer_load_pfp_ucode(struct kgsl_device *device,
+static inline int adreno_ringbuffer_load_pfp_ucode(struct kgsl_device *device,
 			unsigned int start, unsigned int end, unsigned int addr)
 {
 	struct adreno_device *adreno_dev = ADRENO_DEVICE(device);

--- a/drivers/gpu/msm2/kgsl_iommu.c
+++ b/drivers/gpu/msm2/kgsl_iommu.c
@@ -1010,7 +1010,7 @@ static int kgsl_iommu_init_sync_lock(struct kgsl_mmu *mmu)
  *
  * Return - int - number of commands.
  */
-inline unsigned int kgsl_iommu_sync_lock(struct kgsl_mmu *mmu,
+static inline unsigned int kgsl_iommu_sync_lock(struct kgsl_mmu *mmu,
 						unsigned int *cmds)
 {
 	struct kgsl_device *device = mmu->device;
@@ -1080,7 +1080,7 @@ inline unsigned int kgsl_iommu_sync_lock(struct kgsl_mmu *mmu,
  *
  * Return - int - number of commands.
  */
-inline unsigned int kgsl_iommu_sync_unlock(struct kgsl_mmu *mmu,
+static inline unsigned int kgsl_iommu_sync_unlock(struct kgsl_mmu *mmu,
 					unsigned int *cmds)
 {
 	struct kgsl_device *device = mmu->device;

--- a/drivers/media/video/msm/gemini/msm_gemini_sync.c
+++ b/drivers/media/video/msm/gemini/msm_gemini_sync.c
@@ -32,7 +32,7 @@ static int release_buf;
 static const int g_max_out_size = 0x7ff000;
 
 /*************** queue helper ****************/
-inline void msm_gemini_q_init(char const *name, struct msm_gemini_q *q_p)
+static inline void msm_gemini_q_init(char const *name, struct msm_gemini_q *q_p)
 {
 	GMN_DBG("%s:%d] %s\n", __func__, __LINE__, name);
 	q_p->name = name;
@@ -42,7 +42,7 @@ inline void msm_gemini_q_init(char const *name, struct msm_gemini_q *q_p)
 	q_p->unblck = 0;
 }
 
-inline void *msm_gemini_q_out(struct msm_gemini_q *q_p)
+static inline void *msm_gemini_q_out(struct msm_gemini_q *q_p)
 {
 	unsigned long flags;
 	struct msm_gemini_q_entry *q_entry_p = NULL;
@@ -68,7 +68,7 @@ inline void *msm_gemini_q_out(struct msm_gemini_q *q_p)
 	return data;
 }
 
-inline int msm_gemini_q_in(struct msm_gemini_q *q_p, void *data)
+static inline int msm_gemini_q_in(struct msm_gemini_q *q_p, void *data)
 {
 	unsigned long flags;
 
@@ -90,7 +90,7 @@ inline int msm_gemini_q_in(struct msm_gemini_q *q_p, void *data)
 	return 0;
 }
 
-inline int msm_gemini_q_in_buf(struct msm_gemini_q *q_p,
+static inline int msm_gemini_q_in_buf(struct msm_gemini_q *q_p,
 	struct msm_gemini_core_buf *buf)
 {
 	struct msm_gemini_core_buf *buf_p;
@@ -108,7 +108,7 @@ inline int msm_gemini_q_in_buf(struct msm_gemini_q *q_p,
 	return 0;
 }
 
-inline int msm_gemini_q_wait(struct msm_gemini_q *q_p)
+static inline int msm_gemini_q_wait(struct msm_gemini_q *q_p)
 {
 	int tm = MAX_SCHEDULE_TIMEOUT; /* 500ms */
 	int rc;
@@ -136,14 +136,14 @@ inline int msm_gemini_q_wait(struct msm_gemini_q *q_p)
 	return rc;
 }
 
-inline int msm_gemini_q_wakeup(struct msm_gemini_q *q_p)
+static inline int msm_gemini_q_wakeup(struct msm_gemini_q *q_p)
 {
 	GMN_DBG("%s:%d] %s\n", __func__, __LINE__, q_p->name);
 	wake_up(&q_p->wait);
 	return 0;
 }
 
-inline int msm_gemini_q_unblock(struct msm_gemini_q *q_p)
+static inline int msm_gemini_q_unblock(struct msm_gemini_q *q_p)
 {
 	GMN_DBG("%s:%d] %s\n", __func__, __LINE__, q_p->name);
 	q_p->unblck = 1;
@@ -151,7 +151,7 @@ inline int msm_gemini_q_unblock(struct msm_gemini_q *q_p)
 	return 0;
 }
 
-inline void msm_gemini_outbuf_q_cleanup(struct msm_gemini_q *q_p)
+static inline void msm_gemini_outbuf_q_cleanup(struct msm_gemini_q *q_p)
 {
 	struct msm_gemini_core_buf *buf_p;
 	GMN_DBG("%s:%d] %s\n", __func__, __LINE__, q_p->name);
@@ -167,7 +167,7 @@ inline void msm_gemini_outbuf_q_cleanup(struct msm_gemini_q *q_p)
 	q_p->unblck = 0;
 }
 
-inline void msm_gemini_q_cleanup(struct msm_gemini_q *q_p)
+static inline void msm_gemini_q_cleanup(struct msm_gemini_q *q_p)
 {
 	void *data;
 	GMN_DBG("%s:%d] %s\n", __func__, __LINE__, q_p->name);

--- a/drivers/media/video/msm/mercury/msm_mercury_sync.c
+++ b/drivers/media/video/msm/mercury/msm_mercury_sync.c
@@ -29,7 +29,7 @@ static struct msm_mercury_core_buf out_buf_local;
 static struct msm_mercury_core_buf in_buf_local;
 
 /*************** queue helper ****************/
-inline void msm_mercury_q_init(char const *name, struct msm_mercury_q *q_p)
+static inline void msm_mercury_q_init(char const *name, struct msm_mercury_q *q_p)
 {
 	MCR_DBG("%s:%d] %s\n", __func__, __LINE__, name);
 	q_p->name = name;
@@ -39,7 +39,7 @@ inline void msm_mercury_q_init(char const *name, struct msm_mercury_q *q_p)
 	q_p->unblck = 0;
 }
 
-inline void *msm_mercury_q_out(struct msm_mercury_q *q_p)
+static inline void *msm_mercury_q_out(struct msm_mercury_q *q_p)
 {
 	unsigned long flags;
 	struct msm_mercury_q_entry *q_entry_p = NULL;
@@ -65,7 +65,7 @@ inline void *msm_mercury_q_out(struct msm_mercury_q *q_p)
 	return data;
 }
 
-inline int msm_mercury_q_in(struct msm_mercury_q *q_p, void *data)
+static inline int msm_mercury_q_in(struct msm_mercury_q *q_p, void *data)
 {
 	unsigned long flags;
 
@@ -87,7 +87,7 @@ inline int msm_mercury_q_in(struct msm_mercury_q *q_p, void *data)
 	return 0;
 }
 
-inline int msm_mercury_q_in_buf(struct msm_mercury_q *q_p,
+static inline int msm_mercury_q_in_buf(struct msm_mercury_q *q_p,
 	struct msm_mercury_core_buf *buf)
 {
 	struct msm_mercury_core_buf *buf_p;
@@ -105,7 +105,7 @@ inline int msm_mercury_q_in_buf(struct msm_mercury_q *q_p,
 	return 0;
 }
 
-inline int msm_mercury_q_wait(struct msm_mercury_q *q_p)
+static inline int msm_mercury_q_wait(struct msm_mercury_q *q_p)
 {
 	int tm = MAX_SCHEDULE_TIMEOUT; /* 500ms */
 	int rc;
@@ -135,14 +135,14 @@ inline int msm_mercury_q_wait(struct msm_mercury_q *q_p)
 	return rc;
 }
 
-inline int msm_mercury_q_wakeup(struct msm_mercury_q *q_p)
+static inline int msm_mercury_q_wakeup(struct msm_mercury_q *q_p)
 {
 	MCR_DBG("%s:%d] %s\n", __func__, __LINE__, q_p->name);
 	wake_up(&q_p->wait);
 	return 0;
 }
 
-inline int msm_mercury_q_wr_eoi(struct msm_mercury_q *q_p)
+static inline int msm_mercury_q_wr_eoi(struct msm_mercury_q *q_p)
 {
 	MCR_DBG("%s:%d] Wake up %s\n", __func__, __LINE__, q_p->name);
 	q_p->unblck = MSM_MERCURY_EVT_FRAMEDONE;
@@ -150,7 +150,7 @@ inline int msm_mercury_q_wr_eoi(struct msm_mercury_q *q_p)
 	return 0;
 }
 
-inline int msm_mercury_q_wr_err(struct msm_mercury_q *q_p)
+static inline int msm_mercury_q_wr_err(struct msm_mercury_q *q_p)
 {
 	MCR_DBG("%s:%d] Wake up %s\n", __func__, __LINE__, q_p->name);
 	q_p->unblck = MSM_MERCURY_EVT_ERR;
@@ -158,7 +158,7 @@ inline int msm_mercury_q_wr_err(struct msm_mercury_q *q_p)
 	return 0;
 }
 
-inline int msm_mercury_q_unblock(struct msm_mercury_q *q_p)
+static inline int msm_mercury_q_unblock(struct msm_mercury_q *q_p)
 {
 	MCR_DBG("%s:%d] Wake up %s\n", __func__, __LINE__, q_p->name);
 	q_p->unblck = MSM_MERCURY_EVT_UNBLOCK;
@@ -166,7 +166,7 @@ inline int msm_mercury_q_unblock(struct msm_mercury_q *q_p)
 	return 0;
 }
 
-inline void msm_mercury_q_cleanup(struct msm_mercury_q *q_p)
+static inline void msm_mercury_q_cleanup(struct msm_mercury_q *q_p)
 {
 	void *data;
 	MCR_DBG("\n%s:%d] %s\n", __func__, __LINE__, q_p->name);

--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wmm.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wmm.c
@@ -848,7 +848,7 @@ static eHalStatus hdd_wmm_sme_callback (tHalHandle hHal,
       VOS_TRACE( VOS_MODULE_ID_HDD, WMM_TRACE_LEVEL_ERROR,
                  "%s: Setup failed, not a QoS AP\n",
                  __func__);
-      if (!HDD_WMM_HANDLE_IMPLICIT == pQosContext->handle)
+      if ((!HDD_WMM_HANDLE_IMPLICIT) == pQosContext->handle)
       {
          VOS_TRACE(VOS_MODULE_ID_HDD, WMM_TRACE_LEVEL_INFO,
                    "%s: Explicit Qos, notifying userspace",

--- a/drivers/staging/prima/CORE/MAC/src/pe/sch/schBeaconGen.c
+++ b/drivers/staging/prima/CORE/MAC/src/pe/sch/schBeaconGen.c
@@ -93,7 +93,7 @@ tSirRetStatus schGetP2pIeOffset(tANI_U8 *pExtraIe, tANI_U32 extraIeLen, tANI_U16
     {
         if(*pExtraIe == 0xDD)
         {
-            if(palEqualMemory(NULL, (void *)(pExtraIe+2), &P2pOui, sizeof(P2pOui)))
+            if(palEqualMemory(NULL, (void *)(pExtraIe+2), (void *)&P2pOui, sizeof(P2pOui)))
             {
                 status = eSIR_SUCCESS;
                 break;

--- a/drivers/video/msm/mdp4_util.c
+++ b/drivers/video/msm/mdp4_util.c
@@ -1309,7 +1309,7 @@ void mdp4_vg_qseed_init(int vp_num)
 
 }
 
-void mdp4_mixer_blend_init(mixer_num)
+void mdp4_mixer_blend_init(int mixer_num)
 {
 	unsigned char *overlay_base;
 	int off;

--- a/drivers/video/msm/vidc/1080p/resource_tracker/vcd_res_tracker.c
+++ b/drivers/video/msm/vidc/1080p/resource_tracker/vcd_res_tracker.c
@@ -641,7 +641,7 @@ u32 res_trk_set_perf_level(u32 req_perf_lvl, u32 *pn_set_perf_lvl,
 		"set_perf_lvl = %u\n", vidc_freq, req_perf_lvl,
 		(u32)*pn_set_perf_lvl);
 #ifdef CONFIG_MSM_BUS_SCALING
-	if (!res_trk_update_bus_perf_level(dev_ctxt, req_perf_lvl) < 0) {
+	if ((!res_trk_update_bus_perf_level(dev_ctxt, req_perf_lvl)) < 0) {
 		VCDRES_MSG_ERROR("%s(): update buf perf level failed\n",
 			__func__);
 		return false;

--- a/fs/namespace.c
+++ b/fs/namespace.c
@@ -2418,9 +2418,9 @@ SYSCALL_DEFINE5(mount, char __user *, dev_name, char __user *, dir_name,
 		char __user *, type, unsigned long, flags, void __user *, data)
 {
 	int ret;
-	char *kernel_type;
+	char *kernel_type = NULL;
 	char *kernel_dir;
-	char *kernel_dev;
+	char *kernel_dev = NULL;
 	unsigned long data_page;
 
 	ret = copy_mount_string(type, &kernel_type);

--- a/include/linux/wakelock.h
+++ b/include/linux/wakelock.h
@@ -58,7 +58,12 @@ void wake_lock_destroy(struct wake_lock *lock);
 void wake_lock(struct wake_lock *lock);
 void wake_lock_timeout(struct wake_lock *lock, long timeout);
 void wake_unlock(struct wake_lock *lock);
+
+#ifdef CONFIG_WAKELOCK_DEBUG
 void set_debug_lock_timer(int enable, unsigned int timeout);
+#else
+static inline void set_debug_lock_timer(int enable, unsigned int timeout) {}
+#endif
 
 /* wake_lock_active returns a non-zero value if the wake_lock is currently
  * locked. If the wake_lock has a timeout, it does not check the timeout

--- a/kernel/power/Kconfig
+++ b/kernel/power/Kconfig
@@ -32,6 +32,13 @@ config WAKELOCK
 	---help---
 	  Enable wakelocks. When user space request a sleep state the
 	  sleep request will be delayed until no wake locks are held.
+		
+config WAKELOCK_DEBUG
+	bool "Wake lock debug"
+	depends on WAKELOCK
+	default n
+	---help---
+	  printk wakelock debug information
 
 config WAKELOCK_STAT
 	bool "Wake lock stats"

--- a/kernel/power/wakelock.c
+++ b/kernel/power/wakelock.c
@@ -32,7 +32,7 @@ enum {
 	DEBUG_WAKE_LOCK = 1U << 4,
 };
 static int debug_mask = DEBUG_EXIT_SUSPEND |
-				DEBUG_WAKEUP | DEBUG_SUSPEND | DEBUG_EXPIRE;  
+				DEBUG_WAKEUP | DEBUG_SUSPEND | DEBUG_EXPIRE; 
 module_param_named(debug_mask, debug_mask, int, S_IRUGO | S_IWUSR | S_IWGRP);
 
 #define WAKE_LOCK_TYPE_MASK              (0x0f)
@@ -235,6 +235,7 @@ static void print_active_locks(int type)
 	}
 }
 
+#ifdef CONFIG_WAKELOCK_DEBUG
 static void debug_wake_locks(unsigned long notuse)
 {
 	/* Print active wakelocks */
@@ -269,6 +270,7 @@ void set_debug_lock_timer(int enable, unsigned int timeout)
 		mod_timer(&debug_locks_timer, jiffies + timeout);
 }
 EXPORT_SYMBOL(set_debug_lock_timer);
+#endif
 
 static long has_wake_lock_locked(int type)
 {
@@ -658,19 +660,6 @@ int wake_lock_active(struct wake_lock *lock)
 }
 EXPORT_SYMBOL(wake_lock_active);
 
-static int wakelock_stats_open(struct inode *inode, struct file *file)
-{
-	return single_open(file, wakelock_stats_show, NULL);
-}
-
-static const struct file_operations wakelock_stats_fops = {
-	.owner = THIS_MODULE,
-	.open = wakelock_stats_open,
-	.read = seq_read,
-	.llseek = seq_lseek,
-	.release = single_release,
-};
-
 static int __init wakelocks_init(void)
 {
 	int ret;
@@ -715,6 +704,20 @@ static int __init wakelocks_init(void)
 	}
 
 #ifdef CONFIG_WAKELOCK_STAT
+	
+	static int wakelock_stats_open(struct inode *inode, struct file *file)
+	{
+		return single_open(file, wakelock_stats_show, NULL);
+	}
+	
+	static const struct file_operations wakelock_stats_fops = {
+	.owner = THIS_MODULE,
+	.open = wakelock_stats_open,
+	.read = seq_read,
+	.llseek = seq_lseek,
+	.release = single_release,
+};
+	
 	proc_create("wakelocks", S_IRUGO, NULL, &wakelock_stats_fops);
 #endif
 

--- a/mm/rmap.c
+++ b/mm/rmap.c
@@ -613,7 +613,7 @@ void page_unlock_anon_vma(struct anon_vma *anon_vma)
  * Returns virtual address or -EFAULT if page's index/offset is not
  * within the range mapped the @vma.
  */
-inline unsigned long
+static inline unsigned long
 vma_address(struct page *page, struct vm_area_struct *vma)
 {
 	pgoff_t pgoff = page->index << (PAGE_CACHE_SHIFT - PAGE_SHIFT);

--- a/sound/soc/codecs/wcd9304.c
+++ b/sound/soc/codecs/wcd9304.c
@@ -4243,7 +4243,7 @@ void sitar_mbhc_cal(struct snd_soc_codec *codec)
 void *sitar_mbhc_cal_btn_det_mp(const struct sitar_mbhc_btn_detect_cfg* btn_det,
 				const enum sitar_mbhc_btn_det_mem mem)
 {
-	void *ret = &btn_det->_v_btn_low;
+	void *ret = (void *)&btn_det->_v_btn_low;
 
 	switch (mem) {
 	case SITAR_BTN_DET_GAIN:

--- a/sound/soc/codecs/wcd9310-oppo.c
+++ b/sound/soc/codecs/wcd9310-oppo.c
@@ -6574,7 +6574,7 @@ void tabla_mbhc_cal(struct snd_soc_codec *codec)
 void *tabla_mbhc_cal_btn_det_mp(const struct tabla_mbhc_btn_detect_cfg* btn_det,
 				const enum tabla_mbhc_btn_det_mem mem)
 {
-	void *ret = &btn_det->_v_btn_low;
+	void *ret = (void *)&btn_det->_v_btn_low;
 
 	switch (mem) {
 	case TABLA_BTN_DET_GAIN:


### PR DESCRIPTION
Wakelock debug output is enabled in standard and there was no way to disable it. I've added a config option for that and made it default. This saves a quite frequent kernel timer and makes sense imo.
Also, most android hackers are using gcc 5.x and/or linaro toolchain. These changes fix all the arising warnings properly so there's no need to change Makefile with -Wno-xxx-yyy. gcc 4.8/4.9 still compiles fine.
What do you think? Thanks!
